### PR TITLE
Decouple seed pipeline to remove hard requirement for RWX storage

### DIFF
--- a/base/03_services/tekton/kustomization.yaml
+++ b/base/03_services/tekton/kustomization.yaml
@@ -12,4 +12,10 @@ bases:
 - templates
 
 resources:
-- seed-run.yaml
+# Uncomment this Pipeline to start the parallel pipeline that requires RWX PVCs to run the tasks.
+#- seed-run.yaml
+# Seed PipelineRuns to build individual component images using RWO PVCs
+- seed-iot-anomaly-detection-run.yaml
+- seed-iot-consumer-run.yaml
+- seed-iot-frontend-run.yaml
+- seed-iot-software-sensor-run.yaml

--- a/base/03_services/tekton/persistent-volume-claims/build-artifacts.rwo.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/build-artifacts.rwo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: build-artifacts-rwo
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/base/03_services/tekton/persistent-volume-claims/build-images.rwo.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/build-images.rwo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: build-images-rwo
+spec:
+  resources:
+    requests:
+      storage: 128Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/base/03_services/tekton/persistent-volume-claims/iot-anomaly-detection.rwo.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/iot-anomaly-detection.rwo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: iot-anomaly-detection-rwo
+spec:
+  resources:
+    requests:
+      storage: 128Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/base/03_services/tekton/persistent-volume-claims/iot-consumer.rwo.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/iot-consumer.rwo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: iot-consumer-rwo
+spec:
+  resources:
+    requests:
+      storage: 128Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/base/03_services/tekton/persistent-volume-claims/iot-frontend.rwo.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/iot-frontend.rwo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: iot-frontend-rwo
+spec:
+  resources:
+    requests:
+      storage: 128Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/base/03_services/tekton/persistent-volume-claims/iot-software-sensor.rwo.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/iot-software-sensor.rwo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: iot-software-sensor-rwo
+spec:
+  resources:
+    requests:
+      storage: 128Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/base/03_services/tekton/persistent-volume-claims/kustomization.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/kustomization.yaml
@@ -9,3 +9,11 @@ resources:
 - stage-production.yaml
 - build-artifacts.yaml
 - build-images.yaml
+# These are ReadWriteOnce PVCs that will be used for the individual component seed pipelines
+- iot-consumer.rwo.yaml
+- iot-frontend.rwo.yaml
+- iot-software-sensor.rwo.yaml
+- iot-anomaly-detection.rwo.yaml
+- stage-production.rwo.yaml
+- build-artifacts.rwo.yaml
+- build-images.rwo.yaml

--- a/base/03_services/tekton/persistent-volume-claims/stage-production.rwo.yaml
+++ b/base/03_services/tekton/persistent-volume-claims/stage-production.rwo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stage-production-rwo
+spec:
+  resources:
+    requests:
+      storage: 128Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/base/03_services/tekton/pipelines/kustomization.yaml
+++ b/base/03_services/tekton/pipelines/kustomization.yaml
@@ -7,3 +7,8 @@ resources:
 - stage-production.yaml
 - seed.yaml
 - build-images.yaml
+# Seed Pipelines to build individual component images using RWO PVCs
+- seed-iot-anomaly-detection.yaml
+- seed-iot-consumer.yaml
+- seed-iot-frontend.yaml
+- seed-iot-software-sensor.yaml

--- a/base/03_services/tekton/pipelines/seed-iot-anomaly-detection.yaml
+++ b/base/03_services/tekton/pipelines/seed-iot-anomaly-detection.yaml
@@ -1,0 +1,189 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: seed-iot-anomaly-detection
+spec:
+  workspaces:
+  - name: gitrepos
+  - name: config
+  - name: github-secret
+  - name: argocd-env-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-anomaly
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-anomaly
+    - name: version_file_path
+      value: components/iot-anomaly-detection/VERSION
+
+  - name: s2i-build-iot-anomaly
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-anomaly-detection
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/rhscl/python-36-rhel7
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
+
+  - name: copy-image-to-remote-registry-iot-anomaly
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-anomaly
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_ANOMALY_REMOTE_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: origin $(tasks.bump-build-version-iot-anomaly.results.git-tag)
+
+  - name: modify-ops-test-iot-anomaly
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_ANOMALY
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: modify-ops-prod-iot-anomaly
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - modify-ops-test-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_ANOMALY
+    - name: ENVIRONMENT
+      value: PROD
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-prod-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops
+    - name: PUSH_FLAGS
+      value: --set-upstream origin master

--- a/base/03_services/tekton/pipelines/seed-iot-consumer.yaml
+++ b/base/03_services/tekton/pipelines/seed-iot-consumer.yaml
@@ -1,0 +1,190 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: seed-iot-consumer
+spec:
+  workspaces:
+  - name: gitrepos 
+  - name: config
+  - name: github-secret
+  - name: argocd-env-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-consumer
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-consumer
+    - name: version_file_path
+      value: components/iot-consumer/VERSION
+
+  - name: s2i-build-iot-consumer
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-consumer 
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-consumer
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/rhscl/nodejs-10-rhel7
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+
+  - name: copy-image-to-remote-registry-iot-consumer
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-consumer
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_CONSUMER_REMOTE_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-consumer
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: origin $(tasks.bump-build-version-iot-consumer.results.git-tag)
+
+
+  - name: modify-ops-test-iot-consumer
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_CONSUMER
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: modify-ops-prod-iot-consumer
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - modify-ops-test-iot-consumer
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_CONSUMER
+    - name: ENVIRONMENT
+      value: PROD
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-prod-iot-consumer
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config 
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops
+    - name: PUSH_FLAGS
+      value: --set-upstream origin master

--- a/base/03_services/tekton/pipelines/seed-iot-frontend.yaml
+++ b/base/03_services/tekton/pipelines/seed-iot-frontend.yaml
@@ -1,0 +1,192 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: seed-iot-frontend
+spec:
+  workspaces:
+  - name: gitrepos 
+  - name: config
+  - name: github-secret
+  - name: argocd-env-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-frontend
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-frontend
+    - name: version_file_path
+      value: components/iot-frontend/VERSION
+
+  - name: s2i-build-iot-frontend
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-frontend
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-frontend
+    - name: BUILDER_IMAGE
+      value: nodeshift/ubi8-s2i-web-app
+    - name: CHAINED_BUILD_DOCKERFILE
+      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
+
+  - name: copy-image-to-remote-registry-iot-frontend
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-frontend
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_FRONTEND_REMOTE_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-frontend
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: origin $(tasks.bump-build-version-iot-frontend.results.git-tag)
+
+
+  - name: modify-ops-test-iot-frontend
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_FRONTEND
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: modify-ops-prod-iot-frontend
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - modify-ops-test-iot-frontend
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_FRONTEND
+    - name: ENVIRONMENT
+      value: PROD
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-prod-iot-frontend
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config 
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops
+    - name: PUSH_FLAGS
+      value: --set-upstream origin master

--- a/base/03_services/tekton/pipelines/seed-iot-software-sensor.yaml
+++ b/base/03_services/tekton/pipelines/seed-iot-software-sensor.yaml
@@ -1,0 +1,189 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: seed-iot-software-sensor
+spec:
+  workspaces:
+  - name: gitrepos 
+  - name: config
+  - name: github-secret
+  - name: argocd-env-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: master
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-software-sensor
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-swsensor
+    - name: version_file_path
+      value: components/iot-software-sensor/VERSION
+
+  - name: s2i-build-iot-software-sensor
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-software-sensor
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-software-sensor
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-software-sensor.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
+
+  - name: copy-image-to-remote-registry-iot-software-sensor
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-software-sensor
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-software-sensor.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_SWSENSOR_REMOTE_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-software-sensor 
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: origin $(tasks.bump-build-version-iot-software-sensor.results.git-tag)
+
+  - name: modify-ops-test-iot-software-sensor
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_SWSENSOR
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-software-sensor.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: modify-ops-prod-iot-software-sensor
+    taskRef:
+      name: gitops-imagetag
+    runAfter: 
+    - modify-ops-test-iot-software-sensor
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_SWSENSOR
+    - name: ENVIRONMENT
+      value: PROD
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-software-sensor.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-prod-iot-software-sensor
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config 
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops
+    - name: PUSH_FLAGS
+      value: --set-upstream origin master

--- a/base/03_services/tekton/seed-iot-anomaly-detection-run.yaml
+++ b/base/03_services/tekton/seed-iot-anomaly-detection-run.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: seed-iot-anomaly-detection-run
+  namespace: manuela-ci
+spec:
+  pipelineRef:
+    name: seed-iot-anomaly-detection
+  serviceAccountName: pipeline
+  timeout: 1h0m0s
+  workspaces:
+  - configMap:
+      name: environment
+    name: config
+  - name: github-secret
+    secret:
+      secretName: github
+  - name: argocd-env-secret
+    secret:
+      secretName: argocd-env
+  - name: quay-secret
+    secret:
+      secretName: quay-build-secret
+  - name: build-artifacts
+    persistentVolumeClaim:
+      claimName: build-artifacts-rwo
+  - name: gitrepos
+    persistentVolumeClaim:
+      claimName: iot-anomaly-detection-rwo

--- a/base/03_services/tekton/seed-iot-consumer-run.yaml
+++ b/base/03_services/tekton/seed-iot-consumer-run.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: seed-iot-consumer-run
+  namespace: manuela-ci
+spec:
+  pipelineRef:
+    name: seed-iot-consumer
+  serviceAccountName: pipeline
+  timeout: 1h0m0s
+  workspaces:
+  - configMap:
+      name: environment
+    name: config
+  - name: github-secret
+    secret:
+      secretName: github
+  - name: argocd-env-secret
+    secret:
+      secretName: argocd-env
+  - name: quay-secret
+    secret:
+      secretName: quay-build-secret
+  - name: build-artifacts
+    persistentVolumeClaim:
+      claimName: build-artifacts-rwo
+  - name: gitrepos
+    persistentVolumeClaim:
+      claimName: iot-consumer-rwo

--- a/base/03_services/tekton/seed-iot-frontend-run.yaml
+++ b/base/03_services/tekton/seed-iot-frontend-run.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: seed-iot-frontend-run
+  namespace: manuela-ci
+spec:
+  pipelineRef:
+    name: seed-iot-frontend
+  serviceAccountName: pipeline
+  timeout: 1h0m0s
+  workspaces:
+  - configMap:
+      name: environment
+    name: config
+  - name: github-secret
+    secret:
+      secretName: github
+  - name: argocd-env-secret
+    secret:
+      secretName: argocd-env
+  - name: quay-secret
+    secret:
+      secretName: quay-build-secret
+  - name: build-artifacts
+    persistentVolumeClaim:
+      claimName: build-artifacts-rwo
+  - name: gitrepos
+    persistentVolumeClaim:
+      claimName: iot-frontend-rwo

--- a/base/03_services/tekton/seed-iot-software-sensor-run.yaml
+++ b/base/03_services/tekton/seed-iot-software-sensor-run.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: seed-iot-software-sensor-run
+  namespace: manuela-ci
+spec:
+  pipelineRef:
+    name: seed-iot-software-sensor
+  serviceAccountName: pipeline
+  timeout: 1h0m0s
+  workspaces:
+  - configMap:
+      name: environment
+    name: config
+  - name: github-secret
+    secret:
+      secretName: github
+  - name: argocd-env-secret
+    secret:
+      secretName: argocd-env
+  - name: quay-secret
+    secret:
+      secretName: quay-build-secret
+  - name: build-artifacts
+    persistentVolumeClaim:
+      claimName: build-artifacts-rwo
+  - name: gitrepos
+    persistentVolumeClaim:
+      claimName: iot-software-sensor-rwo

--- a/base/03_services/tekton/templates/seed-iot-anomaly-detection.yaml
+++ b/base/03_services/tekton/templates/seed-iot-anomaly-detection.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: seed-iot-anomaly-detection
+objects:
+- apiVersion: tekton.dev/v1beta1
+  kind: PipelineRun
+  metadata:
+    generateName: seed-
+  spec:
+    pipelineRef:
+      name: seed
+    workspaces:
+    - name: config
+      configMap:
+        name: environment
+    - name: github-secret
+      secret:
+        secretName: github
+    - name: argocd-env-secret
+      secret:
+        secretName: argocd-env
+    - name: quay-secret
+      secret:
+        secretName: quay-build-secret
+    - name: build-artifacts
+      persistentVolumeClaim:
+        claimName: build-artifacts
+    - name: gitrepos
+      # volumeClaimTemplate:
+      #   spec:
+      #     accessModes: 
+      #     - ReadWriteMany
+      #     resources:
+      #       requests:
+      #         storage: 1Gi
+      persistentVolumeClaim:
+        claimName: iot-consumer

--- a/base/03_services/tekton/templates/seed-iot-consumer.yaml
+++ b/base/03_services/tekton/templates/seed-iot-consumer.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: seed-iot-consumer
+objects:
+- apiVersion: tekton.dev/v1beta1
+  kind: PipelineRun
+  metadata:
+    generateName: seed-
+  spec:
+    pipelineRef:
+      name: seed
+    workspaces:
+    - name: config
+      configMap:
+        name: environment
+    - name: github-secret
+      secret:
+        secretName: github
+    - name: argocd-env-secret
+      secret:
+        secretName: argocd-env
+    - name: quay-secret
+      secret:
+        secretName: quay-build-secret
+    - name: build-artifacts
+      persistentVolumeClaim:
+        claimName: build-artifacts
+    - name: gitrepos
+      # volumeClaimTemplate:
+      #   spec:
+      #     accessModes: 
+      #     - ReadWriteMany
+      #     resources:
+      #       requests:
+      #         storage: 1Gi
+      persistentVolumeClaim:
+        claimName: iot-consumer

--- a/base/03_services/tekton/templates/seed-iot-frontend.yaml
+++ b/base/03_services/tekton/templates/seed-iot-frontend.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: seed-iot-frontend
+objects:
+- apiVersion: tekton.dev/v1beta1
+  kind: PipelineRun
+  metadata:
+    generateName: seed-
+  spec:
+    pipelineRef:
+      name: seed
+    workspaces:
+    - name: config
+      configMap:
+        name: environment
+    - name: github-secret
+      secret:
+        secretName: github
+    - name: argocd-env-secret
+      secret:
+        secretName: argocd-env
+    - name: quay-secret
+      secret:
+        secretName: quay-build-secret
+    - name: build-artifacts
+      persistentVolumeClaim:
+        claimName: build-artifacts
+    - name: gitrepos
+      # volumeClaimTemplate:
+      #   spec:
+      #     accessModes: 
+      #     - ReadWriteMany
+      #     resources:
+      #       requests:
+      #         storage: 1Gi
+      persistentVolumeClaim:
+        claimName: iot-consumer

--- a/base/03_services/tekton/templates/seed-iot-software-sensor.yaml
+++ b/base/03_services/tekton/templates/seed-iot-software-sensor.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: seed-iot-software-sensor
+objects:
+- apiVersion: tekton.dev/v1beta1
+  kind: PipelineRun
+  metadata:
+    generateName: seed-
+  spec:
+    pipelineRef:
+      name: seed
+    workspaces:
+    - name: config
+      configMap:
+        name: environment
+    - name: github-secret
+      secret:
+        secretName: github
+    - name: argocd-env-secret
+      secret:
+        secretName: argocd-env
+    - name: quay-secret
+      secret:
+        secretName: quay-build-secret
+    - name: build-artifacts
+      persistentVolumeClaim:
+        claimName: build-artifacts
+    - name: gitrepos
+      # volumeClaimTemplate:
+      #   spec:
+      #     accessModes: 
+      #     - ReadWriteMany
+      #     resources:
+      #       requests:
+      #         storage: 1Gi
+      persistentVolumeClaim:
+        claimName: iot-consumer


### PR DESCRIPTION
This is a quick fix to "un-parallelize" the seed pipeline as a workaround for the requirement to make RWX storage available on the management hub running the CI/CD.