### PR TITLE
Use volumeClaimTemplates for PVC creation in PipelineRuns

### DIFF
--- a/base/02_cluster-addons/04_openshift-pipelines/openshift-pipelines-operator-subscription.yaml
+++ b/base/02_cluster-addons/04_openshift-pipelines/openshift-pipelines-operator-subscription.yaml
@@ -5,3 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   installPlanApproval: Automatic
+  channel: preview
+  name: openshift-pipelines-operator-rh 
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace 

--- a/base/03_services/tekton/kustomization.yaml
+++ b/base/03_services/tekton/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: manuela-ci
 
 bases:
-- persistent-volume-claims
+# - persistent-volume-claims #TODO: Remove the creation of PVC when volumeClaimTemplates are working successfully
 - configmaps
 - secrets
 - tasks

--- a/base/03_services/tekton/seed-iot-anomaly-detection-run.yaml
+++ b/base/03_services/tekton/seed-iot-anomaly-detection-run.yaml
@@ -22,8 +22,22 @@ spec:
     secret:
       secretName: quay-build-secret
   - name: build-artifacts
-    persistentVolumeClaim:
-      claimName: build-artifacts-rwo
+    # persistentVolumeClaim:
+    #   claimName: build-artifacts-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
   - name: gitrepos
-    persistentVolumeClaim:
-      claimName: iot-anomaly-detection-rwo
+    # persistentVolumeClaim:
+    #   claimName: iot-anomaly-detection-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi

--- a/base/03_services/tekton/seed-iot-consumer-run.yaml
+++ b/base/03_services/tekton/seed-iot-consumer-run.yaml
@@ -22,8 +22,22 @@ spec:
     secret:
       secretName: quay-build-secret
   - name: build-artifacts
-    persistentVolumeClaim:
-      claimName: build-artifacts-rwo
+    # persistentVolumeClaim:
+    #   claimName: build-artifacts-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
   - name: gitrepos
-    persistentVolumeClaim:
-      claimName: iot-consumer-rwo
+    # persistentVolumeClaim:
+    #   claimName: iot-consumer-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi

--- a/base/03_services/tekton/seed-iot-frontend-run.yaml
+++ b/base/03_services/tekton/seed-iot-frontend-run.yaml
@@ -22,8 +22,22 @@ spec:
     secret:
       secretName: quay-build-secret
   - name: build-artifacts
-    persistentVolumeClaim:
-      claimName: build-artifacts-rwo
+    # persistentVolumeClaim:
+    #   claimName: build-artifacts-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
   - name: gitrepos
-    persistentVolumeClaim:
-      claimName: iot-frontend-rwo
+    # persistentVolumeClaim:
+    #   claimName: iot-frontend-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi

--- a/base/03_services/tekton/seed-iot-software-sensor-run.yaml
+++ b/base/03_services/tekton/seed-iot-software-sensor-run.yaml
@@ -22,8 +22,22 @@ spec:
     secret:
       secretName: quay-build-secret
   - name: build-artifacts
-    persistentVolumeClaim:
-      claimName: build-artifacts-rwo
+    # persistentVolumeClaim:
+    #   claimName: build-artifacts-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
   - name: gitrepos
-    persistentVolumeClaim:
-      claimName: iot-software-sensor-rwo
+    # persistentVolumeClaim:
+    #   claimName: iot-software-sensor-rwo
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi

--- a/base/03_services/tekton/seed-run.yaml
+++ b/base/03_services/tekton/seed-run.yaml
@@ -22,8 +22,22 @@ spec:
     secret:
       secretName: quay-build-secret
   - name: build-artifacts
-    persistentVolumeClaim:
-      claimName: build-artifacts
+    # persistentVolumeClaim:
+    #   claimName: build-artifacts
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            storage: 1Gi
   - name: gitrepos
-    persistentVolumeClaim:
-      claimName: iot-consumer
+    # persistentVolumeClaim:
+    #   claimName: iot-consumer
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            storage: 128Mi

--- a/base/03_services/tekton/templates/build-image-bumpversion.yaml
+++ b/base/03_services/tekton/templates/build-image-bumpversion.yaml
@@ -21,15 +21,15 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: build-images
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi
+      # persistentVolumeClaim:
+      #   claimName: build-images
     params:
     - name: PATH_CONTEXT
       value: tekton/images/bumpversiontask

--- a/base/03_services/tekton/templates/build-image-httpd-ionic.yaml
+++ b/base/03_services/tekton/templates/build-image-httpd-ionic.yaml
@@ -21,15 +21,15 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: build-images
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Gi
+      # persistentVolumeClaim:
+      #   claimName: build-images
     params:
     - name: PATH_CONTEXT
       value: tekton/images/httpd-ionic

--- a/base/03_services/tekton/templates/build-image-pushprox.yaml
+++ b/base/03_services/tekton/templates/build-image-pushprox.yaml
@@ -21,15 +21,15 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: build-images
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi
+      # persistentVolumeClaim:
+      #   claimName: build-images
     params:
     - name: PATH_CONTEXT
       value: tekton/images/pushprox

--- a/base/03_services/tekton/templates/build-iot-anomaly-detection.yaml
+++ b/base/03_services/tekton/templates/build-iot-anomaly-detection.yaml
@@ -21,18 +21,25 @@ objects:
       secret:
         secretName: argocd-env
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-anomaly-detection
+      # persistentVolumeClaim:
+      #   claimName: iot-anomaly-detection
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
       value: registry.access.redhat.com/rhscl/python-36-rhel7

--- a/base/03_services/tekton/templates/build-iot-consumer.yaml
+++ b/base/03_services/tekton/templates/build-iot-consumer.yaml
@@ -21,18 +21,25 @@ objects:
       secret:
         secretName: argocd-env
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-consumer
+      # persistentVolumeClaim:
+      #   claimName: iot-consumer
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
       value: registry.access.redhat.com/rhscl/nodejs-10-rhel7

--- a/base/03_services/tekton/templates/build-iot-frontend.yaml
+++ b/base/03_services/tekton/templates/build-iot-frontend.yaml
@@ -21,18 +21,25 @@ objects:
       secret:
         secretName: argocd-env
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-frontend
+      # persistentVolumeClaim:
+      #   claimName: iot-frontend
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app

--- a/base/03_services/tekton/templates/build-iot-software-sensor-quarkus.yaml
+++ b/base/03_services/tekton/templates/build-iot-software-sensor-quarkus.yaml
@@ -21,18 +21,25 @@ objects:
       secret:
         secretName: argocd-env
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-software-sensor
+      # persistentVolumeClaim:
+      #   claimName: iot-software-sensor
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
       value: quay.io/quarkus/ubi-quarkus-native-s2i:19.3.1-java11

--- a/base/03_services/tekton/templates/build-iot-software-sensor.yaml
+++ b/base/03_services/tekton/templates/build-iot-software-sensor.yaml
@@ -21,18 +21,25 @@ objects:
       secret:
         secretName: argocd-env
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-software-sensor
+      # persistentVolumeClaim:
+      #   claimName: iot-software-sensor
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
       value: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift

--- a/base/03_services/tekton/templates/seed-iot-anomaly-detection.yaml
+++ b/base/03_services/tekton/templates/seed-iot-anomaly-detection.yaml
@@ -24,15 +24,22 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-consumer
+      # persistentVolumeClaim:
+      #   claimName: iot-consumer
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi

--- a/base/03_services/tekton/templates/seed-iot-consumer.yaml
+++ b/base/03_services/tekton/templates/seed-iot-consumer.yaml
@@ -24,15 +24,22 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-consumer
+      # persistentVolumeClaim:
+      #   claimName: iot-consumer
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi

--- a/base/03_services/tekton/templates/seed-iot-frontend.yaml
+++ b/base/03_services/tekton/templates/seed-iot-frontend.yaml
@@ -24,15 +24,22 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-consumer
+      # persistentVolumeClaim:
+      #   claimName: iot-consumer
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 128Mi

--- a/base/03_services/tekton/templates/seed-iot-software-sensor.yaml
+++ b/base/03_services/tekton/templates/seed-iot-software-sensor.yaml
@@ -24,15 +24,22 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-consumer
+      # persistentVolumeClaim:
+      #   claimName: iot-consumer
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi

--- a/base/03_services/tekton/templates/seed.yaml
+++ b/base/03_services/tekton/templates/seed.yaml
@@ -24,15 +24,22 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: build-artifacts
-      persistentVolumeClaim:
-        claimName: build-artifacts
+      # persistentVolumeClaim:
+      #   claimName: build-artifacts
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: iot-consumer
+      # persistentVolumeClaim:
+      #   claimName: iot-consumer
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi

--- a/base/03_services/tekton/templates/stage-production-pipelinerun.yaml
+++ b/base/03_services/tekton/templates/stage-production-pipelinerun.yaml
@@ -31,15 +31,15 @@ objects:
       secret:
         secretName: quay-build-secret
     - name: gitrepos
-      # volumeClaimTemplate:
-      #   spec:
-      #     accessModes: 
-      #     - ReadWriteMany
-      #     resources:
-      #       requests:
-      #         storage: 1Gi
-      persistentVolumeClaim:
-        claimName: stage-production
+      volumeClaimTemplate:
+        spec:
+          accessModes: 
+          - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
+      # persistentVolumeClaim:
+      #   claimName: stage-production
 parameters:
 - name: TAG
 - name: SOURCE_IMAGE


### PR DESCRIPTION
When using pre-existing filesystem PVCs during PipelineRuns, the runs will fail when it attempts to mount 2 or more volumes that exist on different nodes. This change will update the openshift-pipelines to v1.1.1, which is tech preview in OCP4.5, and use `volumeClaimTemplates` to create unique PVCs for each PipelineRun