### PR TITLE
Add startingCSV to pipelines OLM subscription

### DIFF
--- a/base/02_cluster-addons/04_openshift-pipelines/kustomization.yaml
+++ b/base/02_cluster-addons/04_openshift-pipelines/kustomization.yaml
@@ -1,8 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-- github.com/sa-mw-dach/manuela-dev//operator_subscriptions/openshift-pipelines?ref=master
-
-patchesStrategicMerge:
+resources:
 - openshift-pipelines-operator-subscription.yaml

--- a/base/02_cluster-addons/04_openshift-pipelines/openshift-pipelines-operator-subscription.yaml
+++ b/base/02_cluster-addons/04_openshift-pipelines/openshift-pipelines-operator-subscription.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   installPlanApproval: Automatic
   channel: preview
-  name: openshift-pipelines-operator-rh 
-  source: redhat-operators 
-  sourceNamespace: openshift-marketplace 
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: openshift-pipelines-operator.v1.1.1


### PR DESCRIPTION
Set the `startingCSV` for the openshift-pipelines subscription to `v1.1.1` and remove `sa-mw-dach/manuela-dev` as a base resource 

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>