### PR TITLE
Update default quay.io repo for pushing s2i built images

### DIFF
--- a/base/02_cluster-addons/07_tekton/configmaps/environment.yaml
+++ b/base/02_cluster-addons/07_tekton/configmaps/environment.yaml
@@ -8,22 +8,22 @@ data:
   GIT_DEV_REPO_URL: https://github.com/redhat-edge-computing/manuela-dev.git
   GIT_OPS_REPO_TEST_URL: https://github.com/redhat-edge-computing/manuela-gitops.git
   GIT_OPS_REPO_PROD_URL: https://github.com/redhat-edge-computing/manuela-gitops.git
-  IOT_CONSUMER_REMOTE_IMAGE: quay.io/manuela/iot-consumer
+  IOT_CONSUMER_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-consumer
   IOT_CONSUMER_YAML_PATH: images.(name==messaging).newTag
   IOT_CONSUMER_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_CONSUMER_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/messaging/kustomization.yaml
   IOT_CONSUMER_PROD_IMAGESTREAM_PATH: config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
-  IOT_FRONTEND_REMOTE_IMAGE: quay.io/manuela/iot-frontend
+  IOT_FRONTEND_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-frontend
   IOT_FRONTEND_YAML_PATH: images.(name==line-dashboard).newTag
   IOT_FRONTEND_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_FRONTEND_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/line-dashboard/kustomization.yaml
   IOT_FRONTEND_PROD_IMAGESTREAM_PATH: config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
-  IOT_SWSENSOR_REMOTE_IMAGE: quay.io/manuela/iot-software-sensor
+  IOT_SWSENSOR_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-software-sensor
   IOT_SWSENSOR_YAML_PATH: images.(name==machine-sensor).newTag
   IOT_SWSENSOR_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_SWSENSOR_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/machine-sensor/kustomization.yaml
   IOT_SWSENSOR_PROD_IMAGESTREAM_PATH: config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
-  IOT_ANOMALY_REMOTE_IMAGE: quay.io/manuela/iot-anomaly-detection
+  IOT_ANOMALY_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-anomaly-detection
   IOT_ANOMALY_YAML_PATH: images.(name==anomaly-detection).newTag
   IOT_ANOMALY_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_ANOMALY_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/anomaly-detection/kustomization.yaml

--- a/base/02_cluster-addons/07_tekton/secrets/quay-build-secret.yaml
+++ b/base/02_cluster-addons/07_tekton/secrets/quay-build-secret.yaml
@@ -1,3 +1,14 @@
+# Format of .dockerconfigjson is the base64 encode "auths" dictionary
+#
+#{
+#  "auths": {
+#    "quay.io": {
+#      "auth": "SU1BR0VfUkVHSVNUUllfVVNFUjpJTUFHRV9SRUdJU1RSWV9QQVNTV09SRA==",
+#      "email": ""
+#    }
+#  }
+#}
+# auths["quay.io"]["auth"] is a base64 encoded string of IMAGE_REGISTRY_USER:IMAGE_REGISTRY_PASSWORD
 kind: List
 apiVersion: v1
 items:
@@ -6,5 +17,5 @@ items:
   metadata:
     name: quay-build-secret
   data:
-    .dockerconfigjson: ewogICJhdXRocyI6IHsKICAgICJxdWF5LmlvIjogewogICAgICAiYXV0aCI6ICJiV0Z1ZFdWc1lTdGlkV2xzWkRwSFUwczBRVGMzVXpjM1ZFRlpUMVpGVGxWVU9GUTNWRWRVUlZOYU0wSlZSRk5NUVU5VVNWWlhVVlZNUkU1TVNFSTVOVlpLTmpsQk1WTlZPVlpSTVVKTyIsCiAgICAgICJlbWFpbCI6ICIiCiAgICB9CiAgfQp9
+    .dockerconfigjson: ewogICJhdXRocyI6IHsKICAgICJxdWF5LmlvIjogewogICAgICAiYXV0aCI6ICJTVTFCUjBWZlVrVkhTVk5VVWxsZlZWTkZVanBKVFVGSFJWOVNSVWRKVTFSU1dWOVFRVk5UVjA5U1JBPT0iLAogICAgICAiZW1haWwiOiAiIgogICAgfQogIH0KfQo=
   type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Move default image repository images to quay.io/redhat-edge-computing.

**This PR also removes the quay secret from the repo**

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>