### PR TITLE
Add placementRule to select clusters based on label

### DIFF
--- a/base/02_cluster-addons/02_managed-clusters/baremetal-edge.yaml
+++ b/base/02_cluster-addons/02_managed-clusters/baremetal-edge.yaml
@@ -10,6 +10,7 @@ metadata:
     cloud: auto-detect
     vendor: auto-detect
     name: baremetal-edge
+    gitops-mgmt: argocd
   name: baremetal-edge
 spec:
   hubAcceptsClient: true

--- a/base/02_cluster-addons/02_managed-clusters/staging-aws.yaml
+++ b/base/02_cluster-addons/02_managed-clusters/staging-aws.yaml
@@ -10,6 +10,7 @@ metadata:
     cloud: auto-detect
     vendor: auto-detect
     name: staging-aws
+    gitops-mgmt: argocd
   name: staging-aws
 spec:
   hubAcceptsClient: true

--- a/base/02_cluster-addons/02_managed-clusters/staging-gcp.yaml
+++ b/base/02_cluster-addons/02_managed-clusters/staging-gcp.yaml
@@ -10,6 +10,7 @@ metadata:
     cloud: auto-detect
     vendor: auto-detect
     name: staging-gcp
+    gitops-mgmt: argocd
   name: staging-gcp
 spec:
   hubAcceptsClient: true

--- a/base/03_services/argocd-operator-subs/placementrule-labels.yaml
+++ b/base/03_services/argocd-operator-subs/placementrule-labels.yaml
@@ -1,0 +1,10 @@
+# Install ArgoCD on clusters that will use ArgoCD for management of GitOps
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: apply-argocd-to-label-clusters
+  namespace: argocd
+spec:
+  clusterSelector:
+    matchLabels:
+      gitops-mgmt: argocd

--- a/base/03_services/argocd-operator-subs/subscription-labels.yaml
+++ b/base/03_services/argocd-operator-subs/subscription-labels.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+---
+# Apply this subscription to any cluster that has the label specified in the PlacementRule
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: argocd-label-sub
+  namespace: argocd
+  annotations:
+    apps.open-cluster-management.io/github-path: base/02_cluster-addons/03_argocd
+spec:
+  channel: argocd-operator-gitops/argocd-operator-channel
+  name: argocd-sub
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: apply-argocd-to-label-clusters
+      apiGroup: apps.open-cluster-management.io


### PR DESCRIPTION
Adding an alternate ACM PlacementRule & Subscription that uses labels to apply argocd to clusters instead of deploying to all "ready" clusters using `ManagedClusterConditionAvailable`.

This is a possible fix for ArgoCD uninstalling from ManagedClusters when communication with the ACM hub is unavailable.

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>