### PR TITLE
Install manuela factory & line ArgoCD app using ACM

### DIFF
--- a/base/02_cluster-addons/02_managed-clusters/baremetal-edge.yaml
+++ b/base/02_cluster-addons/02_managed-clusters/baremetal-edge.yaml
@@ -11,6 +11,7 @@ metadata:
     vendor: auto-detect
     name: baremetal-edge
     gitops-mgmt: argocd
+    manuela: factory
   name: baremetal-edge
 spec:
   hubAcceptsClient: true

--- a/base/02_cluster-addons/02_managed-clusters/staging-aws.yaml
+++ b/base/02_cluster-addons/02_managed-clusters/staging-aws.yaml
@@ -11,6 +11,7 @@ metadata:
     vendor: auto-detect
     name: staging-aws
     gitops-mgmt: argocd
+    manuela: factory
   name: staging-aws
 spec:
   hubAcceptsClient: true

--- a/base/02_cluster-addons/02_managed-clusters/staging-gcp.yaml
+++ b/base/02_cluster-addons/02_managed-clusters/staging-gcp.yaml
@@ -11,6 +11,7 @@ metadata:
     vendor: auto-detect
     name: staging-gcp
     gitops-mgmt: argocd
+    manuela: factory
   name: staging-gcp
 spec:
   hubAcceptsClient: true

--- a/base/03_services/manuela-factory-subs/channel.yaml
+++ b/base/03_services/manuela-factory-subs/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: acm-channel-blueprint-industrial-edge
+  namespace: acm-blueprint-industrial-edge-gitops
+spec:
+  pathname: https://github.com/redhat-edge-computing/blueprint-industrial-edge.git
+  type: Git

--- a/base/03_services/manuela-factory-subs/namespace.yaml
+++ b/base/03_services/manuela-factory-subs/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acm-blueprint-industrial-edge-gitops

--- a/base/03_services/manuela-factory-subs/placementrule-labels.yaml
+++ b/base/03_services/manuela-factory-subs/placementrule-labels.yaml
@@ -1,0 +1,11 @@
+# Install the Manuela Factory+Line applications on manuela=factory servers running ArgoCD
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: apply-argocd-factory-to-label-clusters
+  namespace: argocd
+spec:
+  clusterSelector:
+    matchLabels:
+      gitops-mgmt: argocd
+      manuela: factory

--- a/base/03_services/manuela-factory-subs/subscription-labels-devcluster-factory.yaml
+++ b/base/03_services/manuela-factory-subs/subscription-labels-devcluster-factory.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+---
+# Apply this subscription to any cluster that has the label specified in the PlacementRule
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: argocd-devcluster-factory-label-sub
+  namespace: argocd
+  annotations:
+    apps.open-cluster-management.io/github-path: >-
+      sites/staging-edge.devcluster.openshift.com/03_services/argocd-gitops-factory
+spec:
+  channel: acm-blueprint-industrial-edge-gitops/acm-channel-blueprint-industrial-edge
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: apply-argocd-factory-to-label-clusters
+      apiGroup: apps.open-cluster-management.io

--- a/base/03_services/manuela-factory-subs/subscription-labels-gcp-devcluster-factory.yaml
+++ b/base/03_services/manuela-factory-subs/subscription-labels-gcp-devcluster-factory.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+---
+# Apply this subscription to any cluster that has the label specified in the PlacementRule
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: argocd-gcp-devcluster-factory-label-sub
+  namespace: argocd
+  annotations:
+    apps.open-cluster-management.io/github-path: >-
+      sites/staging-edge.gcp.devcluster.openshift.com/03_services/argocd-gitops-factory
+spec:
+  channel: acm-blueprint-industrial-edge-gitops/acm-channel-blueprint-industrial-edge
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: apply-argocd-factory-to-label-clusters
+      apiGroup: apps.open-cluster-management.io


### PR DESCRIPTION
This adds ACM objects to deploy the Manuela factory & line ArgoCD applications to ACM `ManagedClusters` using ACM `subscriptions` based on `placementrule` that selects clusters by label.

```
matchLabels:
  gitops-mgmt: argocd
  manuela: factory
```
Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>